### PR TITLE
Feature/topic names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ virtualenv
 .vscode
 **/__pycache__
 **/.DS_Store
+**/*.log

--- a/README.md
+++ b/README.md
@@ -1,11 +1,56 @@
 # LOVE-commander
+
 LOVE service to send SAL commands from http endpoints using salobj
 
-
-
 ## Running tests
-Disabling plugins that may throw errors due to not having write access is recommended: 
+
+Disabling plugins that may throw errors due to not having write access is recommended:
 
 ```
 pytest -p no:cacheprovider -p no:pytest_session2file
 ```
+
+## 1. Use as part of the LOVE system
+
+In order to use the LOVE-commander as part of the LOVE system we recommend to use the docker-compose and configuration files provided in the [LOVE-integration-tools](https://github.com/lsst-ts/LOVE-integration-tools) repo. Please follow the instructions there.
+
+## 2. Local load for development
+
+We provide a docker image and a docker-compose file in order to load the LOVE-commander locally for development purposes, i.e. run tests and build documentation.
+
+This docker-compose does not copy the code into the image, but instead it mounts the repository inside the image, this way you can edit the code from outside the docker container with no need to rebuild or restart.
+
+### 2.1 Load and get into the docker image
+
+Follow these instructions to run the application in a docker container and get into it:
+
+1. Launch and get into the container:
+
+```
+docker-compose up -d
+docker-exec commander bash
+```
+
+2. Inside the container:, load the setup and got to love folder
+
+```
+source .setup.sh
+cd /usr/src/love
+```
+
+### 2.2 Run tests
+
+Once inside the container and in the `love` folder you can run the tests. Disabling plugins that may throw errors due to not having write access is recommended:
+
+```
+pytest -p no:cacheprovider -p no:pytest_session2file
+```
+
+You may filter tests with the `-k <filter-substring>` flag, where `<filter-substring>` can be a file or a test suite name.
+For example the following command:
+
+```
+pytest -p no:cacheprovider -p no:pytest_session2file -k metadata
+```
+
+will run the `test_metadata` test of the `test_salinfo.py` file.

--- a/commander/salinfo.py
+++ b/commander/salinfo.py
@@ -10,11 +10,12 @@ async def create_app(*args, **kwargs):
     salinfo_app = web.Application()
 
     domain = salobj.Domain()
-    available_idl_files = list(domain.idl_dir.glob('**/*.idl'))
-    names = [file.name.split('_', )[-1].replace('.idl', '')
-             for file in available_idl_files]
-    if kwargs.get('remotes_len_limit') is not None:
-        names = names[:kwargs.get('remotes_len_limit')]
+    available_idl_files = list(domain.idl_dir.glob("**/*.idl"))
+    names = [
+        file.name.split("_",)[-1].replace(".idl", "") for file in available_idl_files
+    ]
+    if kwargs.get("remotes_len_limit") is not None:
+        names = names[: kwargs.get("remotes_len_limit")]
 
     salinfos = {}
     for name in names:
@@ -24,17 +25,33 @@ async def create_app(*args, **kwargs):
         results = {
             salinfos[name].metadata.name: {
                 "sal_version": salinfos[name].metadata.sal_version,
-                "xml_version": salinfos[name].metadata.xml_version
+                "xml_version": salinfos[name].metadata.xml_version,
             }
-            for name in salinfos}
+            for name in salinfos
+        }
 
         return web.json_response(results)
-    salinfo_app.router.add_get('/metadata', get_metadata)
+
+    async def get_topic_names(request):
+        results = {
+            name: {
+                "command_names": list(salinfos[name].command_names),
+                "event_names": list(salinfos[name].event_names),
+                "telemetry_names": list(salinfos[name].telemetry_names),
+            }
+            for name in salinfos
+        }
+
+        return web.json_response(results)
+
+    salinfo_app.router.add_get("/metadata", get_metadata)
+    salinfo_app.router.add_get("/topic_names", get_topic_names)
 
     async def on_cleanup(salinfo_app):
         for name in names:
             await salinfos[name].close()
         await domain.close()
+
     salinfo_app.on_cleanup.append(on_cleanup)
 
     return salinfo_app

--- a/commander/salinfo.py
+++ b/commander/salinfo.py
@@ -33,15 +33,17 @@ async def create_app(*args, **kwargs):
         return web.json_response(results)
 
     async def get_topic_names(request):
+        accepted_categories = ["telemetry_names", "event_names", "command_names"]
+        categories = request.rel_url.query.get("categories", "").split("-")
+        categories = [
+            c + "_names" for c in categories if c + "_names" in accepted_categories
+        ]
+        if len(categories) == 0:
+            categories = accepted_categories
         results = {
-            name: {
-                "command_names": list(salinfos[name].command_names),
-                "event_names": list(salinfos[name].event_names),
-                "telemetry_names": list(salinfos[name].telemetry_names),
-            }
+            name: {c: salinfos[name].__getattribute__(c) for c in categories}
             for name in salinfos
         }
-
         return web.json_response(results)
 
     salinfo_app.router.add_get("/metadata", get_metadata)

--- a/commander/salinfo.py
+++ b/commander/salinfo.py
@@ -47,7 +47,7 @@ async def create_app(*args, **kwargs):
         return web.json_response(results)
 
     salinfo_app.router.add_get("/metadata", get_metadata)
-    salinfo_app.router.add_get("/topic_names", get_topic_names)
+    salinfo_app.router.add_get("/topic-names", get_topic_names)
 
     async def on_cleanup(salinfo_app):
         for name in names:

--- a/tests/test_salinfo.py
+++ b/tests/test_salinfo.py
@@ -49,7 +49,7 @@ async def test_all_topic_names(client, *args, **kwargs):
         ]
         names = names[: conftest.REMOTES_LEN_LIMIT]
 
-        response = await client.get("/salinfo/topic_names")
+        response = await client.get("/salinfo/topic-names")
 
         assert response.status == 200
 
@@ -90,7 +90,7 @@ async def test_some_topic_names(client, *args, **kwargs):
             query_param = "-".join(requested)
             # Requeste them
             response = await client.get(
-                "/salinfo/topic_names?categories=" + query_param
+                "/salinfo/topic-names?categories=" + query_param
             )
             assert response.status == 200
             response_data = await response.json()

--- a/tests/test_salinfo.py
+++ b/tests/test_salinfo.py
@@ -2,6 +2,7 @@ import json
 import asyncio
 from aiohttp import web
 from unittest.mock import patch
+from itertools import chain, combinations
 from lsst.ts import salobj
 from commander.app import create_app
 from utils import NumpyEncoder
@@ -36,7 +37,7 @@ async def test_metadata(client, *args, **kwargs):
             assert data["xml_version"].count(".") == 2
 
 
-async def test_topic_names(client, *args, **kwargs):
+async def test_all_topic_names(client, *args, **kwargs):
     """ Test the get topic_names response."""
     salobj.set_random_lsst_dds_domain()
     async with salobj.Domain() as domain:
@@ -53,7 +54,6 @@ async def test_topic_names(client, *args, **kwargs):
         assert response.status == 200
 
         response_data = await response.json()
-        print("response_data: ", response_data)
 
         for name, data in response_data.items():
             assert name in names
@@ -63,3 +63,51 @@ async def test_topic_names(client, *args, **kwargs):
             assert type(data["command_names"]) == list
             assert type(data["event_names"]) == list
             assert type(data["telemetry_names"]) == list
+
+
+async def test_some_topic_names(client, *args, **kwargs):
+    """ Test the use of query params to get only some of the topic_names."""
+    salobj.set_random_lsst_dds_domain()
+    async with salobj.Domain() as domain:
+        domain = salobj.Domain()
+        available_idl_files = list(domain.idl_dir.glob("**/*.idl"))
+        names = [
+            file.name.split("_",)[-1].replace(".idl", "")
+            for file in available_idl_files
+        ]
+        names = names[: conftest.REMOTES_LEN_LIMIT]
+
+        # Get all combinations of categories:
+        categories = ["command", "event", "telemetry"]
+        combs = chain.from_iterable(
+            combinations(categories, r) for r in range(len(categories) + 1)
+        )
+
+        for comb in combs:
+            # Get categories to be requested and not to be requested
+            requested = list(comb)
+            non_req = list(set(categories) - set(requested))
+            query_param = "-".join(requested)
+            # Requeste them
+            response = await client.get(
+                "/salinfo/topic_names?categories=" + query_param
+            )
+            assert response.status == 200
+            response_data = await response.json()
+
+            # If query_params is empty no filtering is applied:
+            if len(requested) == 0:
+                requested = categories
+                non_req = []
+
+            for name, data in response_data.items():
+                assert name in names
+                # Assert that requested categories are in the response
+                for r in requested:
+                    key = r + "_names"
+                    assert key in data
+                    assert type(data[key]) == list
+                # Assert that non-requested categories are NOT in the response
+                for nr in non_req:
+                    key = nr + "_names"
+                    assert key not in data

--- a/tests/test_salinfo.py
+++ b/tests/test_salinfo.py
@@ -11,15 +11,18 @@ index_gen = salobj.index_generator()
 
 
 async def test_metadata(client, *args, **kwargs):
+    """ Test the get metadata response."""
     salobj.set_random_lsst_dds_domain()
     async with salobj.Domain() as domain:
         domain = salobj.Domain()
-        available_idl_files = list(domain.idl_dir.glob('**/*.idl'))
-        names = [file.name.split('_', )[-1].replace('.idl', '')
-                for file in available_idl_files]
-        names = names[:conftest.REMOTES_LEN_LIMIT]
+        available_idl_files = list(domain.idl_dir.glob("**/*.idl"))
+        names = [
+            file.name.split("_",)[-1].replace(".idl", "")
+            for file in available_idl_files
+        ]
+        names = names[: conftest.REMOTES_LEN_LIMIT]
 
-        response = await client.get('/salinfo/metadata')
+        response = await client.get("/salinfo/metadata")
 
         assert response.status == 200
 
@@ -27,7 +30,36 @@ async def test_metadata(client, *args, **kwargs):
 
         for name, data in response_data.items():
             assert name in names
-            assert 'sal_version' in data
-            assert 'xml_version' in data
-            assert data['sal_version'].count('.') == 2
-            assert data['xml_version'].count('.') == 2
+            assert "sal_version" in data
+            assert "xml_version" in data
+            assert data["sal_version"].count(".") == 2
+            assert data["xml_version"].count(".") == 2
+
+
+async def test_topic_names(client, *args, **kwargs):
+    """ Test the get topic_names response."""
+    salobj.set_random_lsst_dds_domain()
+    async with salobj.Domain() as domain:
+        domain = salobj.Domain()
+        available_idl_files = list(domain.idl_dir.glob("**/*.idl"))
+        names = [
+            file.name.split("_",)[-1].replace(".idl", "")
+            for file in available_idl_files
+        ]
+        names = names[: conftest.REMOTES_LEN_LIMIT]
+
+        response = await client.get("/salinfo/topic_names")
+
+        assert response.status == 200
+
+        response_data = await response.json()
+        print("response_data: ", response_data)
+
+        for name, data in response_data.items():
+            assert name in names
+            assert "command_names" in data
+            assert "event_names" in data
+            assert "telemetry_names" in data
+            assert type(data["command_names"]) == list
+            assert type(data["event_names"]) == list
+            assert type(data["telemetry_names"]) == list


### PR DESCRIPTION
Add endpoint to get SAL topic names:
- Url: `salinfo/topic-names`
- Accepts query param `categories` that accepts a list of strings separated by dash characters. Eg: `salinfo/topic-names?categories=telemetry-event`
- Returns a dictionary indexed by IDL names, where each value is a dictionary with the topic names. Eg:

```
{
  ATDome: {
    command_names: [...],
    event_names: [...],
    telemetry_names: [...],
  },
  ATMCS: {
    command_names: [...],
    event_names: [...],
    telemetry_names: [...],
  },
}
```