### PR TITLE
Add dynamic way to set lsstts/develop-env image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM lsstts/develop-env:c0010
+ARG LSSTTS_DEV_VERSION=c0010
+FROM lsstts/develop-env:${LSSTTS_DEV_VERSION}
 
 WORKDIR /usr/src/love/
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,5 @@
-FROM lsstts/develop-env:c0010
+ARG LSSTTS_DEV_VERSION=c0010
+FROM lsstts/develop-env:${LSSTTS_DEV_VERSION}
 
 WORKDIR /usr/src/love/commander
 COPY requirements-dev.txt .

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     registryCredential = "dockerhub-inriachile"
     dockerImageName = "lsstts/love-commander:"
     dockerImage = ""
+    LSSTTS_DEV_VERSION = "c0016.001"
   }
 
   stages {
@@ -31,7 +32,7 @@ pipeline {
           }
           dockerImageName = dockerImageName + image_tag
           echo "dockerImageName: ${dockerImageName}"
-          dockerImage = docker.build dockerImageName
+          dockerImage = docker.build(dockerImageName, "--build-arg LSSTTS_DEV_VERSION=${LSSTTS_DEV_VERSION} .")
         }
       }
     }


### PR DESCRIPTION
This PR makes a refactor to the deploy infrastructure in order to dynamically set the lsstts/develop-env image version. This change is related to the following PR of the LOVE-integration-tools repo: https://github.com/lsst-ts/LOVE-integration-tools/pull/76