### PR TITLE
Add lsstts/develop-env to docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG LSSTTS_DEV_VERSION=c0010
+ARG LSSTTS_DEV_VERSION=develop
 FROM lsstts/develop-env:${LSSTTS_DEV_VERSION}
 
 WORKDIR /usr/src/love/

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-ARG LSSTTS_DEV_VERSION=c0010
+ARG LSSTTS_DEV_VERSION=develop
 FROM lsstts/develop-env:${LSSTTS_DEV_VERSION}
 
 WORKDIR /usr/src/love/commander

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-dev
+      args:
+        LSSTTS_DEV_VERSION: c0017.000
     image: love-commander-image-mount
     volumes:
       - .:/usr/src/love


### PR DESCRIPTION
This PR makes a small change on the Dockerfiles and docker-compose files to include the development version of the lsst develop environment