### PR TITLE
Include pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: check-yaml
+        exclude: conda/meta.yaml
+
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -65,3 +65,18 @@ Once inside the container and in the `love` folder you can build the documentati
 cd docsrc
 ./create_docs.sh
 ```
+
+### Linting & Formatting
+In order to maintaing code linting and formatting we use `pre-commit` that runs **Flake8** (https://flake8.pycqa.org/) and **Black** (https://github.com/psf/black) using Git Hooks. To enable this you have to:
+
+1. Install `pre-commit` in your local development environment:
+```
+pip install pre-commit
+```
+
+2. Set up the git hook scripts running:
+```
+pre-commit install
+```
+
+3. Start developing! Linter and Formatter will be executed on every commit you make


### PR DESCRIPTION
This PR includes a `pre-commit` config file to maintain code linting and formatting using: **Flake8** and **Black**