### PR TITLE
Add TimeOut error when connecting to EFD instance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Version History
 v6.0.2
 -------
 
+* Add TimeOut error when connecting to EFD instance `<https://github.com/lsst-ts/LOVE-commander/pull/48>`_
+
+v6.0.2
+-------
+
 * Add changelog checker `<https://github.com/lsst-ts/LOVE-commander/pull/57>`_
 
 

--- a/python/love/commander/efd.py
+++ b/python/love/commander/efd.py
@@ -9,7 +9,7 @@ EFD_CLIENT_CONNECTION_TIMEOUT = 5
 efd_clients = dict()
 
 
-def riseTimeout(*args):
+def raise_timeout(*args):
     raise TimeoutError
 
 
@@ -26,7 +26,7 @@ def create_app(*args, **kwargs):
     def connect_to_efd_intance(instance):
         global efd_clients
 
-        signal.signal(signal.SIGALRM, riseTimeout)
+        signal.signal(signal.SIGALRM, raise_timeout)
 
         instance_exists = efd_clients.get(instance)
         if instance_exists is not None:
@@ -37,6 +37,8 @@ def create_app(*args, **kwargs):
             efd_clients[instance] = lsst_efd_client.EfdClient(instance)
         except Exception:
             efd_clients[instance] = None
+        finally:
+            signal.signal(signal.SIGALRM, signal.SIG_IGN)
         return efd_clients[instance]
 
     def unavailable_efd_client():

--- a/python/love/commander/efd.py
+++ b/python/love/commander/efd.py
@@ -6,7 +6,7 @@ import lsst_efd_client
 from astropy.time import Time, TimeDelta
 import asyncio
 
-MAX_EFD_LOGS_LEN = 10
+MAX_EFD_LOGS_LEN = 100
 efd_clients = dict()
 
 

--- a/python/love/commander/efd.py
+++ b/python/love/commander/efd.py
@@ -1,13 +1,16 @@
-"""Define the Heartbeats subapplication, which provides the endpoints to
-request a heartbeat.
-"""
+import signal
 from aiohttp import web
 import lsst_efd_client
 from astropy.time import Time, TimeDelta
 import asyncio
 
 MAX_EFD_LOGS_LEN = 100
+EFD_CLIENT_CONNECTION_TIMEOUT = 5
 efd_clients = dict()
+
+
+def riseTimeout(*args):
+    raise TimeoutError
 
 
 def create_app(*args, **kwargs):
@@ -22,11 +25,15 @@ def create_app(*args, **kwargs):
 
     def connect_to_efd_intance(instance):
         global efd_clients
+
+        signal.signal(signal.SIGALRM, riseTimeout)
+
         instance_exists = efd_clients.get(instance)
         if instance_exists is not None:
             return instance_exists
 
         try:
+            signal.alarm(EFD_CLIENT_CONNECTION_TIMEOUT)
             efd_clients[instance] = lsst_efd_client.EfdClient(instance)
         except Exception:
             efd_clients[instance] = None


### PR DESCRIPTION
This PR adds a Timeout exception when trying to connect to an EFD instance. This was added to give more feedback to the user as before the system got stuck when querying instances that it doesn't have access. Also the total of EFD logs retrieved was adjusted to `100`.