### PR TITLE
Update aiohttp-devtools to latest version 1.0.post0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 devtools==0.5.1
-aiohttp-devtools==0.13.1
+aiohttp-devtools==1.0.post0
 watchgod==0.6
 Sphinx==2.4.4
 sphinx-rtd-theme==0.5.0


### PR DESCRIPTION
This PR updates `aiohttp-devtools` to its latest version as the previous one stopped working after a `lsst-develop-env` image update.