### PR TITLE
Extend LFA endpoint to allow LOVE config files uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker-compose exec commander bash
 
 ```
 source /home/saluser/.setup_dev.sh # Here some configurations will be loaded and you will enter another bash.
-pip install /usr/src/love # Install the love.commander package
+pip install -e /usr/src/love # Install the love.commander package
 cd /usr/src/love
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 COPY docker/start-daemon.sh .
 
 USER root
-RUN chown -R saluser:saluser /usr/src/love/python/love
+RUN chown -R saluser:saluser /usr/src/love
 USER saluser
 
 RUN source /home/saluser/.setup_dev.sh && \

--- a/docker/Dockerfile-deploy
+++ b/docker/Dockerfile-deploy
@@ -5,9 +5,10 @@ WORKDIR /usr/src/love/
 COPY . .
 
 USER root
-RUN chown -R saluser:saluser /usr/src/love/python/love
+RUN chown -R saluser:saluser /usr/src/love
 USER saluser
 
+ARG idl
 RUN source /home/saluser/.setup_sal_env.sh && \
     pip install kafkit[aiohttp] aiokafka lsst_efd_client && \
     pip install -r requirements-dev.txt && \

--- a/docker/start-daemon-dev.sh
+++ b/docker/start-daemon-dev.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 source /home/saluser/.setup_dev.sh
-pip install /usr/src/love/
+pip install -e /usr/src/love/
 adev runserver /usr/src/love/python/love/commander -p 5000

--- a/python/love/commander/__init__.py
+++ b/python/love/commander/__init__.py
@@ -26,3 +26,4 @@ from .heartbeats import *
 from .lovecsc import *
 from .salinfo import *
 from .tcs import *
+from .utils import *

--- a/python/love/commander/lfa.py
+++ b/python/love/commander/lfa.py
@@ -70,7 +70,7 @@ def create_app(*args, **kwargs):
         except Exception as e:
             logging.warning(e)
             LOVE_controller = None
-    
+
     def make_connections():
         """Make connections to the LOVE CSC and the S3 bucket.
 
@@ -84,7 +84,7 @@ def create_app(*args, **kwargs):
             connect_to_s3_bucket()
         if not LOVE_controller:
             connect_to_love_controller()
-    
+
     async def check_file_exists(request):
         """Check if a file exists in the S3 bucket.
 
@@ -109,7 +109,8 @@ def create_app(*args, **kwargs):
         if not s3_bucket:
             return unavailable_s3_bucket()
 
-        file_key = request.match_info["file_key"]
+        json_req = await request.json()
+        file_key = json_req["file_key"]
         return await check_file_exists_in_s3_bucket(s3_bucket, file_key)
 
     async def upload_love_config_file(request):
@@ -140,7 +141,7 @@ def create_app(*args, **kwargs):
             return unavailable_s3_bucket()
         if not LOVE_controller:
             return unavailable_love_controller()
-        
+
         # Wait for the LOVE controller to be ready
         await LOVE_controller.start_task
 
@@ -179,7 +180,7 @@ def create_app(*args, **kwargs):
             return unavailable_s3_bucket()
         if not LOVE_controller:
             return unavailable_love_controller()
-        
+
         # Wait for the LOVE controller to be ready
         await LOVE_controller.start_task
 

--- a/python/love/commander/utils.py
+++ b/python/love/commander/utils.py
@@ -43,6 +43,29 @@ def unavailable_love_controller():
         {"ack": "LOVE CSC could not stablish connection"}, status=400
     )
 
+async def check_file_exists_in_s3_bucket(s3_bucket, file_key):
+    """Check if a file exists in the S3 bucket.
+
+    Parameters
+    ----------
+    s3_bucket: S3Bucket
+        The S3 bucket to check if the file exists
+    file_key: str
+        The key of the file to check if it exists
+
+    Returns
+    -------
+    Response
+        The response for the HTTP request with the following structure:
+
+        .. code-block:: json
+
+            {
+                "exists": "<True if the file exists, False otherwise>"
+            }
+    """
+    exists = await s3_bucket.exists(file_key)
+    return web.json_response({"exists": exists})
 
 async def upload_file_to_s3_bucket(field, s3_bucket, LOVE_controller, generator):
     """Handle file upload for LOVE config requests.

--- a/python/love/commander/utils.py
+++ b/python/love/commander/utils.py
@@ -1,0 +1,117 @@
+from aiohttp import web
+from lsst.ts import utils
+from tempfile import TemporaryFile
+
+
+def unavailable_s3_bucket():
+    """Return a response for the case when the S3 bucket is not available.
+
+    Returns
+    -------
+    Response
+        The response for the HTTP request with the following structure:
+
+        .. code-block:: json
+
+            {
+                "ack": "<Description about the \
+                success state of the request>"
+            }
+    """
+    return web.json_response(
+        {"ack": "Could not stablish connection with S3 Bucket "},
+        status=400,
+    )
+
+
+def unavailable_love_controller():
+    """Return a response for the case when the LOVE CSC is not available.
+
+    Returns
+    -------
+    Response
+        The response for the HTTP request with the following structure:
+
+        .. code-block:: json
+
+            {
+                "ack": "<Description about the \
+                success state of the request>"
+            }
+    """
+    return web.json_response(
+        {"ack": "LOVE CSC could not stablish connection"}, status=400
+    )
+
+
+async def upload_file_to_s3_bucket(field, s3_bucket, LOVE_controller, generator):
+    """Handle file upload for LOVE config requests.
+
+    Parameters
+    ----------
+    field: MultipartReader
+        The file uploaded on the HTTP request
+    s3_bucket: S3Bucket
+        The S3 bucket to upload the file
+    LOVE_controller: salobj.Controller
+        The LOVE CSC controller
+    generator: str
+        The generator of the file, used for custom LOVE purposes
+
+    Returns
+    -------
+    Response
+        The response for the HTTP request with the following structure:
+
+        .. code-block:: json
+
+            {
+                "ack": "<Description about the \
+                success state of the request>",
+                "url": "<URL to the uploaded file, if successful>"
+            }
+    """
+
+    try:
+        assert field.name == "uploaded_file"
+    except AssertionError:
+        return web.json_response(
+            {"ack": "Request must have a file uploaded"},
+            status=400,
+        )
+
+    filename = field.filename
+    file_type = filename.split(".")[-1]
+    key = s3_bucket.make_key(
+        salname="LOVE",
+        salindexname=0,
+        generator=generator,
+        date=utils.astropy_time_from_tai_unix(utils.current_tai()),
+        suffix="." + file_type,
+    )
+
+    try:
+        with TemporaryFile() as f:
+            file_data = await field.read()
+            f.write(file_data)
+            f.seek(0)
+            await s3_bucket.upload(fileobj=f, key=key)
+        new_url = f"{s3_bucket.service_resource.meta.client.meta.endpoint_url}/{s3_bucket.name}/{key}"
+    except Exception as e:
+        return web.json_response(
+            {"ack": f"File could not be uploaded: {e}"},
+            status=400,
+        )
+
+    await LOVE_controller.evt_largeFileObjectAvailable.set_write(
+        url=new_url,
+        generator=f"{LOVE_controller.salinfo.name}:{LOVE_controller.salinfo.index}",
+    )
+
+    return web.json_response(
+        {
+            "ack": "Added new file to S3 bucket",
+            "url": new_url,
+        },
+        status=200,
+    )

--- a/python/love/commander/utils.py
+++ b/python/love/commander/utils.py
@@ -43,6 +43,7 @@ def unavailable_love_controller():
         {"ack": "LOVE CSC could not stablish connection"}, status=400
     )
 
+
 async def check_file_exists_in_s3_bucket(s3_bucket, file_key):
     """Check if a file exists in the S3 bucket.
 
@@ -65,7 +66,9 @@ async def check_file_exists_in_s3_bucket(s3_bucket, file_key):
             }
     """
     exists = await s3_bucket.exists(file_key)
-    return web.json_response({"exists": exists})
+    status = 200 if exists else 404
+    return web.json_response({"exists": exists}, status=status)
+
 
 async def upload_file_to_s3_bucket(field, s3_bucket, LOVE_controller, generator):
     """Handle file upload for LOVE config requests.

--- a/tests/test_lfa.py
+++ b/tests/test_lfa.py
@@ -30,17 +30,17 @@ class MockAsyncS3Bucket:
     def make_key(self, salname, salindexname, generator, date, suffix):
         return "test-key"
 
-    
     async def exists(self, key):
         f = asyncio.Future()
         f.set_result(True)
-        return f
+        return True
 
     async def upload(self, fileobj, key):
         f = asyncio.Future()
         data = {}
         f.set_result(data)
         return f
+
 
 async def test_lfa_file_exists(aiohttp_client):
     """Test LFA file existence."""
@@ -53,12 +53,13 @@ async def test_lfa_file_exists(aiohttp_client):
     mock_lfa_client = mock_lfa_patcher.start()
     mock_lfa_client.return_value = MockAsyncS3Bucket()
 
-    response = await client.post("/lfa/file-exists", data={"file_key": "test-key"})
+    response = await client.post("/lfa/file-exists", json={"file_key": "test-key"})
 
     assert response.status == 200
     response_data = await response.json()
     assert "exists" in response_data
     assert response_data["exists"] is True
+
 
 async def test_lfa_upload_file(aiohttp_client):
     """Test LFA file upload."""


### PR DESCRIPTION
This PR extends the LFA endpoint in order to allow users to upload LOVE config files to the LSST S3 bucket (LFA). A extra features were added thinking in future implementations.