### PR TITLE
Change query_efd_logs to allow timestamp scale specification

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.0.4
+-------
+
+* Change query_efd_logs to allow timestamp scale specification `<https://github.com/lsst-ts/LOVE-commander/pull/58>`_
+
 v6.0.3
 -------
 

--- a/python/love/commander/efd.py
+++ b/python/love/commander/efd.py
@@ -111,6 +111,7 @@ def create_app(*args, **kwargs):
             start_date = req["start_date"]
             end_date = req["end_date"]
             cscs = req["cscs"]
+            scale = req["scale"]
         except Exception:
             return web.json_response(
                 {"ack": "Some of the required parameters is not present"}, status=400
@@ -122,8 +123,8 @@ def create_app(*args, **kwargs):
         if efd_client is None:
             return unavailable_efd_client()
 
-        start_date = Time(start_date, scale="utc")
-        end_date = Time(end_date, scale="utc")
+        start_date = Time(start_date, scale=scale).utc
+        end_date = Time(end_date, scale=scale).utc
         query_tasks = []
         sources = []
         for csc in cscs:

--- a/tests/test_efd.py
+++ b/tests/test_efd.py
@@ -174,6 +174,7 @@ async def test_efd_logmessages(aiohttp_client):
         "start_date": "2020-03-16T12:00:00",
         "end_date": "2020-03-17T12:00:00",
         "cscs": cscs,
+        "scale": "utc",
     }
     response = await client.post("/efd/logmessages/", json=request_data)
     assert response.status == 200


### PR DESCRIPTION
This PR extends the `efd.query_efd_logs` logs method to allow configuring the scale to use. Timestamps can come in UTC or TAI scale, so we need to difference this case per case.
Realted to: https://github.com/lsst-ts/LOVE-frontend/pull/484.