### PR TITLE
Refactor way of getting component names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.0.5
+------
+
+* Refactor way of getting component names `<https://github.com/lsst-ts/LOVE-commander/pull/59>`_
+
 v6.0.4
 -------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,6 @@ __version__ = "{version}"
 """
 
 [tool.pytest.ini_options]
-addopts = "--black --flake8 --ignore-glob=*/version.py"
-flake8-ignore = ["E133", "E203", "E226", "E228", "N802", "N803", "N806", "N812", "N813", "N815", "N816", "W503"]
-flake8-max-line-length = 110
-flake8-max-doc-length = 79
 asyncio_mode = "auto"
 
 [project.optional-dependencies]

--- a/python/love/commander/salinfo.py
+++ b/python/love/commander/salinfo.py
@@ -3,6 +3,7 @@ info from SAL.
 """
 from aiohttp import web
 from lsst.ts import salobj
+from lsst.ts import xml
 
 
 def create_app(*args, **kwargs):
@@ -16,18 +17,14 @@ def create_app(*args, **kwargs):
     salinfo_app = web.Application()
 
     domain = salobj.Domain()
-    available_idl_files = list(domain.idl_dir.glob("**/*.idl"))
-    names = [
-        file.name.split("_",)[
-            -1
-        ].replace(".idl", "")
-        for file in available_idl_files
-    ]
+    available_component_names = xml.subsystems
     if kwargs.get("remotes_len_limit") is not None:
-        names = names[: kwargs.get("remotes_len_limit")]
+        available_component_names = available_component_names[
+            : kwargs.get("remotes_len_limit")
+        ]
 
     salinfos = {}
-    for name in names:
+    for name in available_component_names:
         salinfos[name] = salobj.SalInfo(domain, name)
 
     async def get_metadata(request):
@@ -252,7 +249,7 @@ def create_app(*args, **kwargs):
         salinfo_app : object
             The SAL Info application
         """
-        for name in names:
+        for name in available_component_names:
             await salinfos[name].close()
         await domain.close()
 

--- a/tests/test_salinfo.py
+++ b/tests/test_salinfo.py
@@ -1,11 +1,28 @@
 from itertools import chain, combinations
 from lsst.ts import salobj
-from lsst.ts.utils import index_generator
-from tests import conftest
+from lsst.ts import xml
 from love.commander.app import create_app
 
-index_gen = index_generator()
-idl_glob = "**/*.idl"
+
+async def test_all_sal_components(aiohttp_client):
+    """Test the get topic_names response.
+    Ensure that all SAL components are listed.
+    """
+
+    # Arrange
+    ac = await anext(aiohttp_client)  # noqa
+    client = await ac(create_app())
+
+    salobj.set_random_lsst_dds_partition_prefix()
+    async with salobj.Domain():
+        response = await client.get("/salinfo/topic-names")
+
+        assert response.status == 200
+
+        response_data = await response.json()
+
+        for name in xml.subsystems:
+            assert name in response_data
 
 
 async def test_metadata(aiohttp_client):
@@ -16,31 +33,18 @@ async def test_metadata(aiohttp_client):
     client = await ac(create_app())
 
     salobj.set_random_lsst_dds_partition_prefix()
-    async with salobj.Domain() as domain:
-        domain = salobj.Domain()
-        available_idl_files = list(domain.idl_dir.glob(idl_glob))
-        names = [
-            file.name.split(
-                "_",
-            )[
-                -1
-            ].replace(".idl", "")
-            for file in available_idl_files
-        ]
-        names = names[: conftest.REMOTES_LEN_LIMIT]
-
+    async with salobj.Domain():
         response = await client.get("/salinfo/metadata")
 
         assert response.status == 200
 
         response_data = await response.json()
 
-        for name, data in response_data.items():
-            # assert name in names
+        for _, data in response_data.items():
             assert "sal_version" in data
             assert "xml_version" in data
             assert data["sal_version"].count(".") == 2
-            assert data["xml_version"].count(".") == 2
+            assert data["xml_version"].count(".") == 3
 
 
 async def test_all_topic_names(aiohttp_client):
@@ -51,27 +55,14 @@ async def test_all_topic_names(aiohttp_client):
     client = await ac(create_app())
 
     salobj.set_random_lsst_dds_partition_prefix()
-    async with salobj.Domain() as domain:
-        domain = salobj.Domain()
-        available_idl_files = list(domain.idl_dir.glob(idl_glob))
-        names = [
-            file.name.split(
-                "_",
-            )[
-                -1
-            ].replace(".idl", "")
-            for file in available_idl_files
-        ]
-        names = names[: conftest.REMOTES_LEN_LIMIT]
-
+    async with salobj.Domain():
         response = await client.get("/salinfo/topic-names")
 
         assert response.status == 200
 
         response_data = await response.json()
 
-        for name, data in response_data.items():
-            # assert name in names
+        for _, data in response_data.items():
             assert "command_names" in data
             assert "event_names" in data
             assert "telemetry_names" in data
@@ -88,19 +79,7 @@ async def test_some_topic_names(aiohttp_client):
     client = await ac(create_app())
 
     salobj.set_random_lsst_dds_partition_prefix()
-    async with salobj.Domain() as domain:
-        domain = salobj.Domain()
-        available_idl_files = list(domain.idl_dir.glob(idl_glob))
-        names = [
-            file.name.split(
-                "_",
-            )[
-                -1
-            ].replace(".idl", "")
-            for file in available_idl_files
-        ]
-        names = names[: conftest.REMOTES_LEN_LIMIT]
-
+    async with salobj.Domain():
         # Get all combinations of categories:
         categories = ["command", "event", "telemetry"]
         combs = chain.from_iterable(
@@ -112,7 +91,7 @@ async def test_some_topic_names(aiohttp_client):
             requested = list(comb)
             non_req = list(set(categories) - set(requested))
             query_param = "-".join(requested)
-            # Requeste them
+            # Request them
             response = await client.get(
                 "/salinfo/topic-names?categories=" + query_param
             )
@@ -166,19 +145,7 @@ async def test_all_topic_data(aiohttp_client, *args, **kwargs):
     client = await ac(create_app())
 
     salobj.set_random_lsst_dds_partition_prefix()
-    async with salobj.Domain() as domain:
-        domain = salobj.Domain()
-        available_idl_files = list(domain.idl_dir.glob(idl_glob))
-        names = [
-            file.name.split(
-                "_",
-            )[
-                -1
-            ].replace(".idl", "")
-            for file in available_idl_files
-        ]
-        names = names[: conftest.REMOTES_LEN_LIMIT]
-
+    async with salobj.Domain():
         response = await client.get("/salinfo/topic-data")
 
         assert response.status == 200
@@ -202,19 +169,7 @@ async def test_some_topic_data(aiohttp_client, *args, **kwargs):
     client = await ac(create_app())
 
     salobj.set_random_lsst_dds_partition_prefix()
-    async with salobj.Domain() as domain:
-        domain = salobj.Domain()
-        available_idl_files = list(domain.idl_dir.glob(idl_glob))
-        names = [
-            file.name.split(
-                "_",
-            )[
-                -1
-            ].replace(".idl", "")
-            for file in available_idl_files
-        ]
-        names = names[: conftest.REMOTES_LEN_LIMIT]
-
+    async with salobj.Domain():
         # Get all combinations of categories:
         categories = ["command", "event", "telemetry"]
         combs = chain.from_iterable(


### PR DESCRIPTION
This PR removes a parameter that is being deprecated: `salobj.Domain.idl_dir`. This was being used to get the list of all SAL components, now this is being done using the `lsst.ts.xml` package.