### PR TITLE
Hotfix for Jenkinsfile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.0.6
 ------
 
+* Hotfix for Jenkinsfile `<https://github.com/lsst-ts/LOVE-commander/pull/65>`_
 * Move docs creation to CI `<https://github.com/lsst-ts/LOVE-commander/pull/63>`_
 * Add ts_pre_commit_conf `<https://github.com/lsst-ts/LOVE-commander/pull/64>`_
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,8 +92,10 @@ pipeline {
         }
       }
       when {
-        branch "main"
-        branch "develop"
+        anyOf {
+          branch "main"
+          branch "develop"
+        }
       }
       steps {
         script {


### PR DESCRIPTION
This PR makes a minor change to fix documentation deployment as the `anyOf` block is required in this case.
For further reference check: https://www.jenkins.io/doc/book/pipeline/syntax/

> The when directive allows the Pipeline to determine whether the stage should be executed depending on the given condition. The when directive must contain at least one condition. If the when directive contains more than one condition, all the child conditions must return true for the stage to execute.