### PR TITLE
Add M1M3 Bump Tests reports

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.1.0
+------
+
+* Add M1M3 Bump Tests reports `<https://github.com/lsst-ts/LOVE-commander/pull/66>`_
+
 v6.0.6
 ------
 

--- a/python/love/commander/app.py
+++ b/python/love/commander/app.py
@@ -20,13 +20,15 @@
 
 """Main application, instantiates the aiohtttp app."""
 from aiohttp import web
+
 from .commands import create_app as create_cmd_app
-from .heartbeats import create_app as create_heartbeat_app
-from .salinfo import create_app as create_salinfo_app
-from .lovecsc import create_app as create_lovecsc_app
 from .efd import create_app as create_efd_app
-from .tcs import create_app as create_tcs_app
+from .heartbeats import create_app as create_heartbeat_app
 from .lfa import create_app as create_lfa_app
+from .lovecsc import create_app as create_lovecsc_app
+from .reports import create_app as create_reports_app
+from .salinfo import create_app as create_salinfo_app
+from .tcs import create_app as create_tcs_app
 
 
 def create_app(*args, **kwargs):
@@ -45,6 +47,7 @@ def create_app(*args, **kwargs):
     app.add_subapp("/efd/", create_efd_app())
     app.add_subapp("/tcs/", create_tcs_app())
     app.add_subapp("/lfa/", create_lfa_app())
+    app.add_subapp("/reports/", create_reports_app())
 
     app.add_subapp(
         "/salinfo/",

--- a/python/love/commander/reports.py
+++ b/python/love/commander/reports.py
@@ -1,0 +1,168 @@
+# This file is part of LOVE-commander.
+#
+# Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import logging
+import signal
+from urllib.parse import urlencode, urlunparse
+
+import lsst_efd_client
+from aiohttp import web
+from astropy.time import Time
+from lsst.ts.criopy.m1m3 import BumpTestTimes
+from lsst.ts.xml.tables.m1m3 import force_actuator_from_id
+
+EFD_CLIENT_CONNECTION_TIMEOUT = 5
+SITE_DOMAINS = {
+    "summit_efd": "summit-lsp.lsst.codes",
+    "usdf_efd": "usdf-rsp.slac.stanford.edu",
+}
+CHRONOGRAF_DASHBOARDS_PATHS = {
+    "m1m3_bump_tests": {
+        "summit_efd": "/chronograf/sources/1/dashboards/199",
+        "usdf_efd": "/chronograf/sources/1/dashboards/61",
+    }
+}
+
+efd_clients = dict()
+
+
+def raise_timeout(*args):
+    raise TimeoutError
+
+
+def create_app(*args, **kwargs):
+    """Create the EFD application
+
+    Returns
+    -------
+    object
+        The application instance
+    """
+    reports_app = web.Application()
+
+    def connect_to_efd_intance(instance):
+        global efd_clients
+
+        signal.signal(signal.SIGALRM, raise_timeout)
+
+        instance_exists = efd_clients.get(instance)
+        if instance_exists is not None:
+            return instance_exists
+
+        try:
+            signal.alarm(EFD_CLIENT_CONNECTION_TIMEOUT)
+            efd_clients[instance] = lsst_efd_client.EfdClient(instance)
+        except Exception:
+            efd_clients[instance] = None
+        finally:
+            signal.signal(signal.SIGALRM, signal.SIG_IGN)
+        return efd_clients[instance]
+
+    def unavailable_efd_client():
+        return web.json_response(
+            {"ack": "EFD Client could not stablish connection"}, status=400
+        )
+
+    async def query_m1m3_bump_tests(request):
+        global efd_clients
+        req = await request.json()
+
+        try:
+            efd_instance = req["efd_instance"]
+            start_date = req["start_date"]
+            end_date = req["end_date"]
+            actuator_id = req["actuator_id"]
+        except Exception:
+            return web.json_response(
+                {"ack": "Some of the required parameters is not present"}, status=400
+            )
+
+        efd_client = efd_clients.get(efd_instance)
+        if efd_client is None:
+            efd_client = connect_to_efd_intance(efd_instance)
+        if efd_client is None:
+            return unavailable_efd_client()
+
+        btt = BumpTestTimes(efd_client)
+
+        logging.info(
+            f"Looking for actuator #{actuator_id} bump test times in {start_date} to {end_date}"
+        )
+        primary, secondary = await btt.find_times(
+            int(actuator_id), Time(start_date), Time(end_date)
+        )
+        actuator = force_actuator_from_id(actuator_id)
+
+        def add_result(start, end, results):
+            def act(index, actuator) -> int:
+                return 0 if index is None else actuator
+
+            params = {
+                "refresh": "Paused",
+                "tempVars[x_index]": act(actuator.x_index, actuator.actuator_id),
+                "tempVars[y_index]": act(actuator.y_index, actuator.actuator_id),
+                "tempVars[z_index]": actuator.actuator_id,
+                "tempVars[s_index]": act(actuator.s_index, actuator.actuator_id),
+                "lower": start.isot + "Z",
+                "upper": end.isot + "Z",
+            }
+            url = urlunparse(
+                (
+                    "https",
+                    SITE_DOMAINS[efd_instance],
+                    CHRONOGRAF_DASHBOARDS_PATHS["m1m3_bump_tests"][efd_instance],
+                    "",
+                    urlencode(params),
+                    "",
+                )
+            )
+            results.append(
+                {
+                    "start": start.isot,
+                    "end": end.isot,
+                    "url": url,
+                }
+            )
+
+        primary_tests = []
+        for bump in primary:
+            add_result(bump[0], bump[1], primary_tests)
+
+        secondary_tests = []
+        for bump in secondary:
+            add_result(bump[0], bump[1], secondary_tests)
+
+        response_data = {
+            "primary": primary_tests,
+            "secondary": secondary_tests,
+        }
+        return web.json_response(response_data)
+
+    reports_app.router.add_post("/m1m3-bump-tests", query_m1m3_bump_tests)
+    reports_app.router.add_post("/m1m3-bump-tests/", query_m1m3_bump_tests)
+
+    async def on_cleanup():
+        pass
+
+    reports_app.on_cleanup.append(on_cleanup)
+
+    return reports_app

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,94 @@
+# This file is part of LOVE-commander.
+#
+# Copyright (c) 2023 Inria Chile.
+#
+# Developed by Inria Chile.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or at
+# your option any later version.
+#
+# This program is distributed in the hope that it will be useful,but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+import random
+from unittest.mock import patch
+
+from astropy.time import Time
+from love.commander.app import create_app
+from love.commander.reports import CHRONOGRAF_DASHBOARDS_PATHS, SITE_DOMAINS
+
+
+class MockEFDClient:
+    pass
+
+
+class MockBumpTestTimes:
+    async def find_times(self, actuator_id, start, end):
+        return (
+            [
+                (Time("2024-01-01T00:00:00"), Time("2024-01-01T01:00:00")),
+                (Time("2024-01-02T00:00:00"), Time("2024-01-02T01:00:00")),
+                (Time("2024-01-03T00:00:00"), Time("2024-01-03T01:00:00")),
+            ],
+            [
+                (Time("2024-01-01T00:00:00"), Time("2024-01-01T01:00:00")),
+                (Time("2024-01-02T00:00:00"), Time("2024-01-02T01:00:00")),
+                (Time("2024-01-03T00:00:00"), Time("2024-01-03T01:00:00")),
+            ],
+        )
+
+
+async def test_query_m1m3_bump_tests(aiohttp_client):
+    """Test the get timeseries response."""
+    # Arrange
+    ac = await anext(aiohttp_client)
+    client = await ac(create_app())
+
+    # Start patching `EfdClient`.
+    mock_efd_patcher = patch("lsst_efd_client.EfdClient")
+    mock_efd_client = mock_efd_patcher.start()
+    mock_efd_client.return_value = MockEFDClient()
+
+    # Start patching `BumpTestTimes`.
+    mock_bump_test_times_patcher = patch("love.commander.reports.BumpTestTimes")
+    mock_bump_test_times = mock_bump_test_times_patcher.start()
+    mock_bump_test_times.return_value = MockBumpTestTimes()
+
+    selected_efd_instance = random.choice(["summit_efd", "usdf_efd"])
+    request_data = {
+        "efd_instance": selected_efd_instance,
+        "start_date": "2024-01-01T00:00:00",
+        "end_date": "2024-01-31T00:00:00",
+        "actuator_id": 437,
+    }
+    response = await client.post("/reports/m1m3-bump-tests/", json=request_data)
+    assert response.status == 200
+
+    response_data = await response.json()
+
+    assert "primary" in response_data
+    assert "secondary" in response_data
+
+    assert len(response_data["primary"]) == 3
+    assert len(response_data["secondary"]) == 3
+
+    assert response_data["primary"][0]["start"] == "2024-01-01T00:00:00.000"
+    assert response_data["primary"][0]["end"] == "2024-01-01T01:00:00.000"
+
+    assert "url" in response_data["primary"][0]
+    assert response_data["primary"][0]["url"].startswith(
+        "https://"
+        + SITE_DOMAINS[selected_efd_instance]
+        + CHRONOGRAF_DASHBOARDS_PATHS["m1m3_bump_tests"][selected_efd_instance]
+    )
+
+    # Stop patches
+    mock_efd_patcher.stop()
+    mock_bump_test_times_patcher.stop()

--- a/tests/test_salinfo.py
+++ b/tests/test_salinfo.py
@@ -19,9 +19,9 @@
 
 
 from itertools import chain, combinations
-from lsst.ts import salobj
-from lsst.ts import xml
+
 from love.commander.app import create_app
+from lsst.ts import salobj, xml
 
 
 async def test_all_sal_components(aiohttp_client):
@@ -64,7 +64,7 @@ async def test_metadata(aiohttp_client):
             assert "sal_version" in data
             assert "xml_version" in data
             assert data["sal_version"].count(".") == 2
-            assert data["xml_version"].count(".") == 3
+            assert data["xml_version"].count(".") == 2
 
 
 async def test_all_topic_names(aiohttp_client):
@@ -86,9 +86,9 @@ async def test_all_topic_names(aiohttp_client):
             assert "command_names" in data
             assert "event_names" in data
             assert "telemetry_names" in data
-            assert type(data["command_names"]) == list
-            assert type(data["event_names"]) == list
-            assert type(data["telemetry_names"]) == list
+            assert isinstance(data["command_names"], list)
+            assert isinstance(data["event_names"], list)
+            assert isinstance(data["telemetry_names"], list)
 
 
 async def test_some_topic_names(aiohttp_client):
@@ -128,7 +128,7 @@ async def test_some_topic_names(aiohttp_client):
                 for r in requested:
                     key = r + "_names"
                     assert key in data
-                    assert type(data[key]) == list
+                    assert isinstance(data[key], list)
                 # Assert that non-requested categories are NOT in the response
                 for nr in non_req:
                     key = nr + "_names"
@@ -137,9 +137,9 @@ async def test_some_topic_names(aiohttp_client):
 
 def assert_topic_data(topic_data):
     """Assert the structure of a topic data."""
-    assert type(topic_data) == dict
+    assert isinstance(topic_data, dict)
     for data in topic_data.values():
-        assert type(data) == dict
+        assert isinstance(data, dict)
         for k in data.keys():
             v = data[k]
             assert "name" in v


### PR DESCRIPTION
This PR adds the `reports` endpoint in order to make specific queries to the EFD to retrieve reports. The `reports/m1m3-bump-tests` endpoint was implemented, it uses the `lsst.ts.criopy.m1m3.BumpTestTimes` class to query M1M3 actuators bump tests reports from the EFD.
Also the `test_metadata` test was adjusted to fix the test and others flake8 suggestions were applied.