### PR TITLE
Remove authlist references

### DIFF
--- a/docsrc/source/modules/how_to_use_it.rst
+++ b/docsrc/source/modules/how_to_use_it.rst
@@ -174,7 +174,6 @@ For example:
         "event_names": [
             "alarm",
             "appliedSettingsMatchStart",
-            "authList",
             "errorCode",
             "heartbeat",
             "logLevel",
@@ -194,7 +193,6 @@ For example:
             "enterControl",
             "exitControl",
             "mute",
-            "setAuthList",
             "setLogLevel",
             "setValue",
             "showAlarms",


### PR DESCRIPTION
This PR removes all references to the Authlist feature as the Authorize CSC has been removed from the Control System.