### PR TITLE
Simplify query_efd_logs function and remove constraint on limit of logs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.2.1
+------
+
+* Simplify query_efd_logs function and remove constraint on limit of logs `<https://github.com/lsst-ts/LOVE-commander/pull/75>`_
+
 v6.2.0
 ------
 

--- a/python/love/commander/efd.py
+++ b/python/love/commander/efd.py
@@ -155,6 +155,9 @@ def create_app(*args, **kwargs):
                 topics = indexes[index]
                 for topic in topics:
                     fields = topics[topic]
+                    # Make sure the private_rcvStamp field is present
+                    if "private_rcvStamp" not in fields:
+                        fields.append("private_rcvStamp")
                     task = efd_client.select_time_series(
                         f"lsst.sal.{csc}.{topic}",
                         fields,


### PR DESCRIPTION
This PR aims to simplify the method to query efd logs by removing the constraint on the maximum number of efd logs to return as response (all are returned now) and also logs are now being sorted in descending order based on the `private_rcvStamp` field of the record.