### PR TITLE
Add COMMAND_TIMEOUTS configuration to set SAL command timeouts

### DIFF
--- a/python/love/commander/commands.py
+++ b/python/love/commander/commands.py
@@ -18,6 +18,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import os
 
 from aiohttp import web
 from lsst.ts import salobj
@@ -38,6 +39,8 @@ def create_app(*args, **kwargs):
     remotes = {}
 
     cmd = web.Application()
+
+    command_timeouts = int(os.environ.get("COMMAND_TIMEOUTS", "10"))
 
     async def start_cmd(request):
         nonlocal domain
@@ -83,7 +86,7 @@ def create_app(*args, **kwargs):
 
         try:
             remotes[remote_name].salinfo.identity = identity
-            cmd_result = await cmd.start(timeout=5)
+            cmd_result = await cmd.start(timeout=command_timeouts)
             return web.json_response({"ack": cmd_result.result})
         except salobj.AckTimeoutError as e:
             msg = (

--- a/python/love/commander/commands.py
+++ b/python/love/commander/commands.py
@@ -85,18 +85,13 @@ def create_app(*args, **kwargs):
             remotes[remote_name].salinfo.identity = identity
             cmd_result = await cmd.start(timeout=5)
             return web.json_response({"ack": cmd_result.result})
-        except salobj.AckTimeoutError:
-            # TODO: uncomment following lines when transitioning to Kafka
-            # See DM-46247.
-            # msg = (
-            #     "No ack received from component."
-            #     if e.ackcmd == salobj.SalRetCode.CMD_NOACK
-            #     else f"Last ack received {e.ackcmd}."
-            # )
-            # return web.json_response({
-            #     "ack": f"Command time out. {msg}"
-            # }, status=504)
-            return web.json_response({"ack": "Done"})
+        except salobj.AckTimeoutError as e:
+            msg = (
+                "No ack received from component."
+                if e.ackcmd == salobj.SalRetCode.CMD_NOACK
+                else f"Last ack received {e.ackcmd}."
+            )
+            return web.json_response({"ack": f"Command time out. {msg}"}, status=504)
 
     cmd.router.add_post("/", start_cmd)
 


### PR DESCRIPTION
This PR adds a COMMAND_TIMEOUTS environmental variable configuration to set SAL command timeouts. Also rollback the command timeouts bad response as Kafka is already in place.