### PR TITLE
Refactor dependency on criopy for BumpTestTimes to use lsst.ts.m1m3.utils.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,3 +23,4 @@ requirements:
     - ts-salobj
     - ts-idl
     - ts-observatory-control
+    - ts-m1m3-utils

--- a/python/love/commander/reports.py
+++ b/python/love/commander/reports.py
@@ -26,7 +26,7 @@ from urllib.parse import urlencode, urlunparse
 import lsst_efd_client
 from aiohttp import web
 from astropy.time import Time
-from lsst.ts.criopy.m1m3 import BumpTestTimes
+from lsst.ts.m1m3.utils import BumpTestTimes
 from lsst.ts.xml.tables.m1m3 import force_actuator_from_id
 
 EFD_CLIENT_CONNECTION_TIMEOUT = 5


### PR DESCRIPTION
This PR refactors the use of `BumpTestTimes` to use `lsst.ts.m1m3.utils` instead of `lsst.ts.criopy`.