### PR TITLE
Refactor reports application to support ts-m1m3-utils v0.3.2.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v7.1.1
+------
+
+* Refactor reports application to support ts-m1m3-utils v0.3.2. `<https://github.com/lsst-ts/LOVE-commander/pull/80>`_
+
 v7.1.0
 ------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Version History
 ===============
 
-v7.0.2
+v7.1.0
 ------
 
 * Add query_efd_most_recent_timeseries method to the efd app in order to query most recent timeseries. `<https://github.com/lsst-ts/LOVE-commander/pull/79>`_

--- a/python/love/commander/efd.py
+++ b/python/love/commander/efd.py
@@ -18,6 +18,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
+import logging
 import math
 import signal
 
@@ -251,8 +252,14 @@ def create_app(*args, **kwargs):
     efd_app.router.add_get("/efd_clients", query_efd_clients)
     efd_app.router.add_get("/efd_clients/", query_efd_clients)
 
-    async def on_cleanup(efd_app):
+    async def on_cleanup(app):
         global efd_clients
+        for instance, client in efd_clients.items():
+            if client is not None:
+                try:
+                    client.close()
+                except Exception as e:
+                    logging.error(f"Error closing EFD client {instance}: {e}")
         efd_clients = dict()
 
     efd_app.on_cleanup.append(on_cleanup)

--- a/python/love/commander/reports.py
+++ b/python/love/commander/reports.py
@@ -162,9 +162,15 @@ def create_app(*args, **kwargs):
     reports_app.router.add_post("/m1m3-bump-tests", query_m1m3_bump_tests)
     reports_app.router.add_post("/m1m3-bump-tests/", query_m1m3_bump_tests)
 
-    async def on_cleanup(reports_app):
-        # This app doesn't require cleaning up.
-        pass
+    async def on_cleanup(app):
+        global efd_clients
+        for instance, client in efd_clients.items():
+            if client is not None:
+                try:
+                    client.close()
+                except Exception as e:
+                    logging.error(f"Error closing EFD client {instance}: {e}")
+        efd_clients = dict()
 
     reports_app.on_cleanup.append(on_cleanup)
 

--- a/python/love/commander/reports.py
+++ b/python/love/commander/reports.py
@@ -109,9 +109,6 @@ def create_app(*args, **kwargs):
         logging.info(
             f"Looking for actuator #{actuator_id} bump test times in {start_date} to {end_date}"
         )
-        primary, secondary = await btt.find_times(
-            int(actuator_id), Time(start_date), Time(end_date)
-        )
         actuator = force_actuator_from_id(actuator_id)
 
         def add_result(start, end, results):
@@ -146,12 +143,16 @@ def create_app(*args, **kwargs):
             )
 
         primary_tests = []
-        for bump in primary:
-            add_result(bump[0], bump[1], primary_tests)
+        async for bump in btt.find_times(
+            actuator, True, Time(start_date), Time(end_date)
+        ):
+            add_result(bump.start_time, bump.end_time, primary_tests)
 
         secondary_tests = []
-        for bump in secondary:
-            add_result(bump[0], bump[1], secondary_tests)
+        async for bump in btt.find_times(
+            actuator, False, Time(start_date), Time(end_date)
+        ):
+            add_result(bump.start_time, bump.end_time, secondary_tests)
 
         response_data = {
             "primary": primary_tests,

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 
 from astropy.time import Time
 from love.commander.reports import CHRONOGRAF_DASHBOARDS_PATHS, SITE_DOMAINS
+from lsst.ts.m1m3.utils.bump_test_times import BumpTest
 
 
 class MockEFDClient:
@@ -29,19 +30,23 @@ class MockEFDClient:
 
 
 class MockBumpTestTimes:
-    async def find_times(self, actuator_id, start, end):
-        return (
-            [
+    async def find_times(self, fa, primary, start, end):
+        if primary:
+            for date_range in [
                 (Time("2024-01-01T00:00:00"), Time("2024-01-01T01:00:00")),
                 (Time("2024-01-02T00:00:00"), Time("2024-01-02T01:00:00")),
                 (Time("2024-01-03T00:00:00"), Time("2024-01-03T01:00:00")),
-            ],
-            [
+            ]:
+                test = BumpTest(fa, date_range[0], date_range[1], None)
+                yield test
+        else:
+            for date_range in [
                 (Time("2024-01-01T00:00:00"), Time("2024-01-01T01:00:00")),
                 (Time("2024-01-02T00:00:00"), Time("2024-01-02T01:00:00")),
                 (Time("2024-01-03T00:00:00"), Time("2024-01-03T01:00:00")),
-            ],
-        )
+            ]:
+                test = BumpTest(fa, date_range[0], date_range[1], None)
+                yield test
 
 
 async def test_query_m1m3_bump_tests(http_client):

--- a/ups/love_commander.table
+++ b/ups/love_commander.table
@@ -3,6 +3,10 @@
 # - Common third-party packages can be assumed to be recursively included by
 #   the "base" package.
 setupRequired(base)
+setupRequired(ts_salobj)
+setupRequired(ts_observatory_control)
+setupRequired(ts_m1m3_utils)
+
 
 # The following is boilerplate for all packages.
 # See https://dmtn-001.lsst.io for details on LSST_LIBRARY_PATH.


### PR DESCRIPTION
This PR does some adjustments to the `query_m1m3_bump_tests` method in order to support the new API for `BumpTestTimes.find_times`.

The cleanup method for `reports` and `efd` applications was adjusted to try closing the respective EFD clients when the service is shut down.